### PR TITLE
Add details to the README.rst about the INSTALLED_APPS setup support.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -59,6 +59,10 @@ Run
 
     python manage.py muttest <app1> <app2> ... [--modules <list of modules to include>]
 
+Note that dotted path entries to AppConfig classes in the `INSTALLED_APPS` is not yet
+supported and a valid app name is expected (which must be listed in the installed apps).
+See the `GitHub Issue <https://github.com/phihos/django-mutpy/issues/3>`_ for details.
+
 .. _MutPy: https://github.com/mutpy/mutpy
 .. |Build Status| image:: https://travis-ci.org/phihos/django-mutpy.svg?branch=master
    :target: https://travis-ci.org/phihos/django-mutpy


### PR DESCRIPTION
As a starter, I'm just adding a little info to the readme to guide people, based on the feedback in Issue #3 .

As a next step, I'd like to evolve the code to get the app name from `AppConfig.name` field.