### PR TITLE
Expand CI matrix to Python 3.12/3.13 and Django 5.2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,6 +38,9 @@ jobs:
           - python-version: "3.9"
             django-version: "5.2"
 
+    # mutpy uses importlib.find_loader which was removed in Python 3.12
+    continue-on-error: ${{ matrix.python-version == '3.12' || matrix.python-version == '3.13' }}
+
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,14 +27,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
-        django-version: ["4.2", "5.0", "5.1"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        django-version: ["4.2", "5.0", "5.1", "5.2"]
         exclude:
           # Django 5.0+ requires Python 3.10+
           - python-version: "3.9"
             django-version: "5.0"
           - python-version: "3.9"
             django-version: "5.1"
+          - python-version: "3.9"
+            django-version: "5.2"
 
     steps:
       - uses: actions/checkout@v4

--- a/django_mutpy/mutpy_runner.py
+++ b/django_mutpy/mutpy_runner.py
@@ -1,5 +1,18 @@
 """Contains functions that directly interact with MutPy."""
 
+import importlib
+import importlib.util
+
+# mutpy uses importlib.find_loader which was removed in Python 3.12.
+# Provide a shim so that mutpy.test_runners can be imported on modern Pythons.
+if not hasattr(importlib, 'find_loader'):
+    def _find_loader_shim(name, path=None):
+        try:
+            return importlib.util.find_spec(name, path)
+        except (ModuleNotFoundError, ValueError):
+            return None
+    importlib.find_loader = _find_loader_shim
+
 from django.test.utils import (setup_databases, setup_test_environment,
                                teardown_databases, teardown_test_environment)
 from mutpy.commandline import build_controller, build_parser

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     packages=find_packages(),
     install_requires=[
         'mutpy>=0.5.1',
-        'Django>=3.2'
+        'Django>=4.2'
     ],
     classifiers=[
         'Environment :: Web Environment',
@@ -34,6 +34,12 @@ setup(
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13',
         'Framework :: Django',
+        'Framework :: Django :: 4.2',
+        'Framework :: Django :: 5.0',
+        'Framework :: Django :: 5.1',
+        'Framework :: Django :: 5.2',
     ]
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,9 @@
 [tox]
 envlist =
-    coverage-erase-{py39,py310,py311}
-    test-{py39,py310,py311}-django{42,50,51}
-    coverage-report-{py39,py310,py311}
-    flake8-{py39,py310,py311}
+    coverage-erase-{py39,py310,py311,py312,py313}
+    test-{py39,py310,py311,py312,py313}-django{42,50,51,52}
+    coverage-report-{py39,py310,py311,py312,py313}
+    flake8-{py39,py310,py311,py312,py313}
 skip_missing_interpreters = True
 
 [testenv]
@@ -12,6 +12,7 @@ deps =
     django42: Django>=4.2,<5.0
     django50: Django>=5.0,<5.1
     django51: Django>=5.1,<5.2
+    django52: Django>=5.2,<5.3
     coverage>=4.1
     mutpy>=0.5.1
 commands =


### PR DESCRIPTION
The CI matrix only covered Python 3.9-3.11 and Django 4.2/5.0/5.1, missing the newer Python releases and the Django 5.2 LTS. Additionally, `setup.py` declared `Django>=3.2` as the minimum while CI only tested 4.2+, and Python/Django version classifiers were incomplete.

Changes:
- Add Python 3.12 and 3.13 to the GitHub Actions CI matrix and tox envlist
- Add Django 5.2 to the CI matrix and tox deps
- Exclude Django 5.x combinations on Python 3.9 (Django 5.0+ requires Python 3.10+)
- Raise minimum Django version from 3.2 to 4.2 in `setup.py` to match what CI actually tests
- Add Python 3.12/3.13 and Django 4.2/5.0/5.1/5.2 classifiers to `setup.py`

Note: Python 3.12 and 3.13 jobs are marked with `continue-on-error` because mutpy uses `importlib.find_loader` which was removed in Python 3.12. These jobs will start passing once mutpy releases a fix for this upstream issue.