### PR TITLE
Remove unused captured_output() function

### DIFF
--- a/tests/test_project/tests.py
+++ b/tests/test_project/tests.py
@@ -3,8 +3,6 @@
 import subprocess
 import sys
 from argparse import ArgumentParser
-from contextlib import contextmanager
-from io import StringIO
 from unittest import TestCase, mock
 from unittest.mock import MagicMock
 
@@ -25,18 +23,6 @@ class Devnull(object):
     def flush(self):
         """Do nothing."""
         pass
-
-
-@contextmanager
-def captured_output():
-    """Capture stdout and stderr."""
-    new_out, new_err = StringIO(), StringIO()
-    old_out, old_err = sys.stdout, sys.stderr
-    try:
-        sys.stdout, sys.stderr = new_out, new_err
-        yield sys.stdout.getvalue().strip(), sys.stderr.getvalue().strip()
-    finally:
-        sys.stdout, sys.stderr = old_out, old_err
 
 
 @mock.patch('django_mutpy.management.commands.muttest.run_mutpy_on_app')


### PR DESCRIPTION
The `captured_output()` context manager in `tests/test_project/tests.py` is defined but never called anywhere in the codebase. This removes the dead function along with the `contextlib.contextmanager` and `io.StringIO` imports that were only used by it.