### PR TITLE
Add lint job to CI workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,22 @@ on:
   pull_request:
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install tox
+        run: pip install tox
+
+      - name: Run linters
+        run: tox -e flake8
+
   test:
     runs-on: ubuntu-latest
     strategy:

--- a/django_mutpy/mutpy_runner.py
+++ b/django_mutpy/mutpy_runner.py
@@ -1,7 +1,9 @@
 """Contains functions that directly interact with MutPy."""
 
-from django.test.utils import setup_databases, setup_test_environment, teardown_databases, teardown_test_environment
+from django.test.utils import (setup_databases, setup_test_environment,
+                               teardown_databases, teardown_test_environment)
 from mutpy.commandline import build_controller, build_parser
+
 from django_mutpy.utils import list_all_modules_in_package
 
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 """Setup script."""
 from os import path
 
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
 
 from django_mutpy import __version__
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Test suite for django-mutpy."""

--- a/tests/manage.py
+++ b/tests/manage.py
@@ -16,7 +16,7 @@ if __name__ == '__main__':
             import django  # noqa
         except ImportError:
             raise ImportError(
-                'Couldn\'t import Django. Are you sure it\'s installed and '
+                "Couldn't import Django. Are you sure it's installed and "
                 'available on your PYTHONPATH environment variable? Did you '
                 'forget to activate a virtual environment?'
             )

--- a/tests/test_app/models.py
+++ b/tests/test_app/models.py
@@ -8,4 +8,5 @@ class SingletonModel(models.Model):
 
     It is used to test the test isolation regarding the database.
     """
+
     unique_field = models.BooleanField(default=True, unique=True)

--- a/tests/test_app/nested/__init__.py
+++ b/tests/test_app/nested/__init__.py
@@ -1,0 +1,1 @@
+"""Nested test package."""

--- a/tests/test_app/nested/nested/__init__.py
+++ b/tests/test_app/nested/nested/__init__.py
@@ -1,0 +1,1 @@
+"""Doubly nested test package."""

--- a/tests/test_app_db/models.py
+++ b/tests/test_app_db/models.py
@@ -8,4 +8,5 @@ class SingletonModel(models.Model):
 
     It is used to test the test isolation regarding the database.
     """
+
     unique_field = models.BooleanField(default=True, unique=True)

--- a/tests/test_app_db/tests.py
+++ b/tests/test_app_db/tests.py
@@ -1,7 +1,6 @@
 """Tests do not actually test django-mutpy, but are run by the tests for testing mutation testing (testception)."""
 
 from django.test import TestCase
-
 from test_app_db.models import SingletonModel
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -32,9 +32,11 @@ deps =
     pep8-naming>=0.4.1
     flake8-debugger>=1.4.0
 commands =
-    isort -rc django_mutpy tests
+    isort --check-only django_mutpy tests
     flake8
 
 [flake8]
 max-line-length=120
 exclude=venv,migrations,.tox
+inline-quotes=single
+avoid-escape=true


### PR DESCRIPTION
The tox.ini already defines a `flake8` lint environment but it was never invoked in the GitHub Actions workflow. This adds a `lint` job that runs `tox -e flake8` and fixes all pre-existing flake8 violations (import ordering, missing package docstrings, class docstring formatting, quote style). Also updates tox.ini to use current isort flags and configures `avoid-escape` for flake8-quotes.