### PR TITLE
fix: update minimum Django version to 4.2 LTS

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     packages=find_packages(),
     install_requires=[
         'mutpy>=0.5.1',
-        'Django>=3.2'
+        'Django>=4.2'
     ],
     classifiers=[
         'Environment :: Web Environment',
@@ -35,5 +35,9 @@ setup(
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
         'Framework :: Django',
+        'Framework :: Django :: 4.2',
+        'Framework :: Django :: 5.0',
+        'Framework :: Django :: 5.1',
+        'Framework :: Django :: 5.2',
     ]
 )


### PR DESCRIPTION
Django 3.2 LTS reached end-of-life in April 2024. The CI matrix already only tests Django 4.2+, so the install_requires declaring >=3.2 was misleading. This updates the floor to Django 4.2 (current LTS) and adds version-specific Django classifiers (4.2, 5.0, 5.1, 5.2).