### PR TITLE
test: add coverage for AppConfig subclass paths in INSTALLED_APPS

### DIFF
--- a/tests/test_app/apps.py
+++ b/tests/test_app/apps.py
@@ -1,0 +1,9 @@
+"""AppConfig for test_app."""
+
+from django.apps import AppConfig
+
+
+class TestAppConfig(AppConfig):
+    """AppConfig subclass for the test_app."""
+
+    name = 'test_app'

--- a/tests/test_project/test_settings.py
+++ b/tests/test_project/test_settings.py
@@ -5,7 +5,7 @@ import os
 SECRET_KEY = 'fake-key'
 INSTALLED_APPS = [
     'test_project',
-    'test_app',
+    'test_app.apps.TestAppConfig',
     'test_app_db',
     'django_mutpy'
 ]

--- a/tests/test_project/tests.py
+++ b/tests/test_project/tests.py
@@ -114,6 +114,14 @@ class MuttestCommandTest(SimpleTestCase):
             'app1', include_list=None, extra_args=['--coverage', '--quiet'],
         )
 
+    def test_delegate_command_with_appconfig_in_installed_apps(self, run_mutpy_on_app):
+        """Check that apps registered via AppConfig dotted path are accepted."""
+        # test_app is registered as 'test_app.apps.TestAppConfig' in settings
+        # when
+        self.run_command(['test_app'])
+        # then
+        run_mutpy_on_app.assert_called_once_with('test_app', include_list=None, extra_args=None)
+
 
 # noinspection PyUnresolvedReferences
 @mock.patch('django_mutpy.mutpy_runner.teardown_databases')
@@ -171,7 +179,8 @@ class UtilsTest(TestCase):
         # when
         all_modules = list_all_modules_in_package('test_app', include_list=None, skip=['tests', 'migrations'])
         # then
-        self.assertEqual(all_modules, ['test_app.calculator',
+        self.assertEqual(all_modules, ['test_app.apps',
+                                       'test_app.calculator',
                                        'test_app.models',
                                        'test_app.nested.nested.nested_module',
                                        'test_app.nested.nested_module'])


### PR DESCRIPTION
The test suite registered all apps via plain name strings in INSTALLED_APPS, so the AppConfig dotted-path code path added in #13 was never exercised by any test. This switches test_app to be registered as `test_app.apps.TestAppConfig` in the test settings and adds a dedicated unit test that verifies the muttest command correctly recognizes apps installed through AppConfig subclasses.

Supersedes #4 which had merge conflicts and took a different approach.