### PR TITLE
Add django-upgrade git hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,6 @@
+repos:
+  - repo: https://github.com/adamchainz/django-upgrade
+    rev: 1.30.0
+    hooks:
+      - id: django-upgrade
+        args: [--target-version, "4.2"]


### PR DESCRIPTION
A small utility to ensure Django version compatibility and a clean codebase in the long run.