### PR TITLE
Add suport for Django 6.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
-        django-version: ["4.2", "5.0", "5.1", "5.2"]
+        django-version: ["4.2", "5.0", "5.1", "5.2", "6.0"]
         exclude:
           # Django 5.0+ requires Python 3.10+
           - python-version: "3.9"
@@ -37,6 +37,13 @@ jobs:
             django-version: "5.1"
           - python-version: "3.9"
             django-version: "5.2"
+          # Django 6.0 requires Python 3.12+
+          - python-version: "3.9"
+            django-version: "6.0"
+          - python-version: "3.10"
+            django-version: "6.0"
+          - python-version: "3.11"
+            django-version: "6.0"
 
     # mutpy uses importlib.find_loader which was removed in Python 3.12
     continue-on-error: ${{ matrix.python-version == '3.12' || matrix.python-version == '3.13' }}

--- a/README.rst
+++ b/README.rst
@@ -19,7 +19,7 @@ Requirements
 ------------
 
 -  Python >= 3.9
--  Django 4.2, 5.0, 5.1, or 5.2
+-  Django 4.2, 5.0, 5.1, 5.2 or 6.0
 -  MutPy >= 0.5.1
 
 Installation

--- a/setup.py
+++ b/setup.py
@@ -41,5 +41,6 @@ setup(
         'Framework :: Django :: 5.0',
         'Framework :: Django :: 5.1',
         'Framework :: Django :: 5.2',
+        'Framework :: Django :: 6.0',
     ]
 )

--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,7 @@ deps =
     django50: Django>=5.0,<5.1
     django51: Django>=5.1,<5.2
     django52: Django>=5.2,<5.3
+    django60: Django>=6.0,<6.1
     coverage>=4.1
     mutpy>=0.5.1
 commands =


### PR DESCRIPTION
Released on Dec 3, 2025

https://docs.djangoproject.com/en/6.0/releases/6.0/